### PR TITLE
bug fixed

### DIFF
--- a/Confluence-html-to-github-markdown.js
+++ b/Confluence-html-to-github-markdown.js
@@ -45,6 +45,8 @@ function dive(dir) {
           mkdirpSync("/Markdown")
 //          console.log("Making Markdown")
           var outputFile = "Markdown/" + match[1].replace(/ /g, "-").replace(/[(|)]/g, "") + ".md"
+		  outputFile = outputFile.replace(/[\/]/g, "-");
+		  outputFile = "Markdown/" + outputFile;
           var out = exec("pandoc -f html -t markdown_github -o " + outputFile + " " + JSON.stringify(path.replace(/ /g, "\ ")), {cwd: process.cwd()})
           console.log(out)
             //images


### PR DESCRIPTION
When I import html from confluence, file name gets backslashes.
It makes error from pandoc. ( backslash recognized as folder directory )

So, it replaces to **-**